### PR TITLE
in sample code of the doc, use ConnOp instead of Connector

### DIFF
--- a/doc/concept/connector-cn.md
+++ b/doc/concept/connector-cn.md
@@ -14,8 +14,8 @@ class DetialState {
     String message;
 }
 
-Connector<DetialState, String> messageConnector() {
-    return Connector<DetialState, String>(
+ConnOp<DetialState, String> messageConnector() {
+    return ConnOp<DetialState, String>(
         get: (DetialState state) => state.message,
         set: (DetialState state, String message) => state.message = message,
     );

--- a/doc/concept/connector.md
+++ b/doc/concept/connector.md
@@ -14,8 +14,8 @@ class DetialState {
     String message;
 }
 
-Connector<DetialState, String> messageConnector() {
-    return Connector<DetialState, String>(
+ConnOp<DetialState, String> messageConnector() {
+    return ConnOp<DetialState, String>(
         get: (DetialState state) => state.message,
         set: (DetialState state, String message) => state.message = message,
     );


### PR DESCRIPTION
in connector sample code of the doc,  replace `Connector` to `ConnOp`

the Connector is deprecated
```dart
/// use ConnOp<T, P> instead of Connector<T, P>
@deprecated
class Connector<T, P> extends MutableConn<T, P>
```