### PR TITLE
ignore site-www branch folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ android/local.properties
 
 # docs
 node_modules/
+docs/


### PR DESCRIPTION
一些被忽略的文件在切换分支后出现在其他分支，已将这些文件加入到.gitignore文件。