### PR TITLE
private_reducer_mixin 进行增强

### DIFF
--- a/lib/src/redux_component_mixin/redux_component_mixin.dart
+++ b/lib/src/redux_component_mixin/redux_component_mixin.dart
@@ -1,5 +1,6 @@
 export 'keep_alive_mixin.dart';
 export 'private_reducer_mixin.dart';
+export 'selfish_reducer_mixin.dart';
 export 'single_ticker_provider_mixin.dart';
 export 'visible_change_mixin.dart';
 export 'widgets_binding_observer_mixin.dart';

--- a/lib/src/redux_component_mixin/selfish_reducer_mixin.dart
+++ b/lib/src/redux_component_mixin/selfish_reducer_mixin.dart
@@ -1,0 +1,77 @@
+import 'package:fish_redux/fish_redux.dart';
+
+/// usage
+/// 1. State implements Compare interface
+/// class MyState implements Cloneable<MyState>,Comparison<MyState>{
+///   ...
+///   int businessId;
+///
+///   @override
+///   bool compare(MyState other) {
+///     return businessId==other.businessId;
+///   }
+///   ...
+/// }
+///
+/// 2. Component add SelfishReducerMixin
+/// class MyComponent extends Component<T> with SelfishReducerMixin<T> {
+///   MyComponent():super(
+///     ///
+///   );
+/// }
+///
+/// 3. Use SelfishAction instead of Action
+/// enum MyAction { edit, done,}
+/// class MyActionCreator {
+///   static Action editAction(MyState myState) {
+///     return SelfishAction(MyAction.edit, payload: myState);
+///   }
+///
+///   static Action doneAction() {
+///     return SelfishAction(MyAction.done);
+///   }
+/// }
+mixin SelfishReducerMixin<T extends Comparison<T>> on Logic<T> {
+  @override
+  Reducer<T> get protectedReducer {
+    final Reducer<T> superReducer = super.protectedReducer;
+    return superReducer != null
+        ? (T state, Action action) {
+      if (action is SelfishAction ) {
+        if(action.target is T &&state.compare(action.target)){
+          return superReducer(state, action.asAction());
+        }else{
+          return state;
+        }
+      }else{
+        return superReducer(state, action);
+      }
+    }
+        : null;
+  }
+
+  @override
+  Dispatch createDispatch(Dispatch effect, Dispatch next, Context<T> ctx) {
+    final Dispatch superDispatch = super.createDispatch(effect, next, ctx);
+    return (Action action) {
+      if (action is SelfishAction) {
+        action.attachTarget(ctx.state);
+      }
+      superDispatch(action);
+    };
+  }
+}
+
+class SelfishAction extends Action{
+  Object target;
+  SelfishAction(Object type, {dynamic payload})
+      : super(type, payload: payload);
+
+  void attachTarget(Object target)=>this.target=target;
+
+  Action asAction() => Action(type, payload: payload);
+}
+
+abstract class Comparison<T extends Comparison<T>> {
+  bool compare(T other);
+}

--- a/test/lib/all_test.dart
+++ b/test/lib/all_test.dart
@@ -4,6 +4,7 @@ import 'redux/redux_test.dart' as redux;
 import 'redux_adapter/redux_adapter_test.dart' as redux_adapter;
 import 'redux_aop/redux_aop_test.dart' as redux_aop;
 import 'redux_component/redux_component_test.dart' as redux_component;
+import 'redux_component_mixin/redux_component_mixin_test.dart' as redux_component_mixin;
 import 'redux_connector/redux_connector_test.dart' as redux_connector;
 import 'redux_middleware/redux_middleware_test.dart' as redux_middleware;
 import 'redux_routes/redux_routes_test.dart' as redux_routes;
@@ -15,6 +16,7 @@ void main() {
     redux_adapter.main();
     redux_aop.main();
     redux_component.main();
+    redux_component_mixin.main();
     redux_connector.main();
     redux_middleware.main();
     redux_routes.main();

--- a/test/lib/redux_component_mixin/redux_component_mixin_test.dart
+++ b/test/lib/redux_component_mixin/redux_component_mixin_test.dart
@@ -1,0 +1,10 @@
+import 'package:test/test.dart';
+
+import 'selfish_reducer_mixin_test.dart' as selfish;
+
+
+void main() {
+  group('redux_component_mixin_test.dart', () {
+    selfish.main();
+  });
+}

--- a/test/lib/redux_component_mixin/selfish_reducer_mixin_test.dart
+++ b/test/lib/redux_component_mixin/selfish_reducer_mixin_test.dart
@@ -1,0 +1,151 @@
+import 'package:fish_redux/fish_redux.dart';
+import 'package:flutter/cupertino.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:test_widgets/test_base.dart';
+
+enum SelfishTestAction { add }
+
+class SelfishTestState
+    implements Cloneable<SelfishTestState>, Comparison<SelfishTestState> {
+  int businessId;
+
+  int count;
+
+  SelfishTestState({this.businessId, this.count});
+
+  @override
+  SelfishTestState clone() {
+    return SelfishTestState(businessId: businessId, count: count);
+  }
+
+  @override
+  bool compare(SelfishTestState other) {
+    return businessId == other.businessId;
+  }
+}
+
+class ListSelfishTestState implements Cloneable<ListSelfishTestState> {
+  List<SelfishTestState> data;
+
+  ListSelfishTestState(this.data);
+
+  @override
+  ListSelfishTestState clone() {
+    return ListSelfishTestState(data);
+  }
+}
+class SelfishTestComponent extends TestComponent<SelfishTestState> with SelfishReducerMixin{
+
+  SelfishTestComponent():super(
+      view: (state, dispatch, viewService) {
+        return Row(
+          children: <Widget>[
+            FlatButton(
+              key: ValueKey<String>('add-${state.businessId}'),
+              onPressed: () {
+                dispatch(SelfishAction(SelfishTestAction.add));
+              },
+              child: Container(
+                padding: const EdgeInsets.all(8.0),
+                height: 28.0,
+                color: Colors.yellow,
+                child: Text(
+                  'desc-${state.count}',
+                  style: TextStyle(fontSize: 16.0),
+                ),
+                alignment: AlignmentDirectional.centerStart,
+              ),
+            ),
+          ],
+        );
+      }, reducer: (SelfishTestState state, Action action) {
+    if (action.type == SelfishTestAction.add) {
+      return state.clone()..count += 1;
+    }
+    return state;
+  }
+  );
+}
+
+
+ListSelfishTestState initState(Map _) => ListSelfishTestState([
+      SelfishTestState(businessId: 1, count: 0),
+      SelfishTestState(businessId: 2, count: 0),
+      SelfishTestState(businessId: 3, count: 0),
+    ]);
+
+Widget buildView(
+    ListSelfishTestState state, Dispatch dispatch, ViewService viewService) {
+  return Column(
+    mainAxisSize: MainAxisSize.min,
+    children: <Widget>[
+      Expanded(
+        child: viewService.buildComponent('SelfishComponent1'),
+      ),
+      Expanded(
+        child: viewService.buildComponent('SelfishComponent2'),
+      ),
+      Expanded(
+        child: viewService.buildComponent('SelfishComponent3'),
+      ),
+    ],
+  );
+}
+
+void main() {
+  group('selfish_reducer_mixin_test', () {
+    testWidgets('reducer', (WidgetTester tester) async {
+      await tester.pumpWidget(TestStub(TestPage<ListSelfishTestState, Map>(
+          initState: initState,
+          view: buildView,
+          dependencies: Dependencies(slots: {
+            'SelfishComponent1': ConnOp<ListSelfishTestState, SelfishTestState>(
+                    get: (ListSelfishTestState list) => list.data[0],
+                    set: (ListSelfishTestState list,
+                            SelfishTestState subState) =>
+                        list.data[0] = subState) +
+                SelfishTestComponent(),
+            'SelfishComponent2': ConnOp<ListSelfishTestState, SelfishTestState>(
+                    get: (ListSelfishTestState list) => list.data[1],
+                    set: (ListSelfishTestState list,
+                            SelfishTestState subState) =>
+                        list.data[1] = subState) +
+                SelfishTestComponent(),
+            'SelfishComponent3': ConnOp<ListSelfishTestState, SelfishTestState>(
+                    get: (ListSelfishTestState list) => list.data[2],
+                    set: (ListSelfishTestState list,
+                            SelfishTestState subState) =>
+                        list.data[2] = subState) +
+                SelfishTestComponent(),
+          })).buildPage(null)));
+
+      expect(find.text('desc-0'), findsNWidgets(3));
+
+      await tester.tap(find.byKey(const ValueKey<String>('add-1')));
+      await tester.pump();
+
+      expect(find.text('desc-0'), findsNWidgets(2));
+      expect(find.text('desc-1'), findsNWidgets(1));
+
+      await tester.tap(find.byKey(const ValueKey<String>('add-2')));
+      await tester.pump();
+
+      expect(find.text('desc-0'), findsNWidgets(1));
+      expect(find.text('desc-1'), findsNWidgets(2));
+
+      await tester.tap(find.byKey(const ValueKey<String>('add-3')));
+      await tester.pump();
+
+      expect(find.text('desc-0'), findsNWidgets(0));
+      expect(find.text('desc-1'), findsNWidgets(3));
+
+      await tester.tap(find.byKey(const ValueKey<String>('add-3')));
+      await tester.pump();
+
+      expect(find.text('desc-0'), findsNWidgets(0));
+      expect(find.text('desc-1'), findsNWidgets(2));
+      expect(find.text('desc-2'), findsNWidgets(1));
+    });
+  });
+}


### PR DESCRIPTION
#### 相比private_reducer_mixin有两个比较大的不同

1. 更细的颗粒度控制,只有使用了SelfishAction才会SelfishReducerMixin所处理

2. 用户能自定义比较的方法,这样做能够减少reducer方法的模板判断代码