### PR TITLE
fix deprecated function for new Flutter sdk

### DIFF
--- a/lib/src/redux_component/page.dart
+++ b/lib/src/redux_component/page.dart
@@ -205,7 +205,7 @@ class PageProvider extends InheritedWidget {
 
   static PageProvider tryOf(BuildContext context) {
     final PageProvider provider =
-        context.inheritFromWidgetOfExactType(PageProvider);
+        context.dependOnInheritedWidgetOfExactType<PageProvider>();
     return provider;
   }
 


### PR DESCRIPTION
- replace inheritFromWidgetOfExactType -> dependOnInheritedWidgetOfExactType

This feature was deprecated after v1.12.1. Use dependOnInheritedWidgetOfExactType instead.